### PR TITLE
Declare statusBarColor as final

### DIFF
--- a/android/src/main/java/no/fuse/rnunity/RNUnityManager.java
+++ b/android/src/main/java/no/fuse/rnunity/RNUnityManager.java
@@ -45,7 +45,7 @@ public class RNUnityManager extends SimpleViewManager<UnityPlayer> implements Li
 
         final Activity activity = reactContext.getCurrentActivity();
         final Handler handler = new Handler(Looper.getMainLooper());
-        int statusBarColor = activity.getWindow().getStatusBarColor();
+        final int statusBarColor = activity.getWindow().getStatusBarColor();
 
         if (player == null) {
             player = new UnityPlayer(activity, this);


### PR DESCRIPTION
OpenJDK8 and higher fails with compiler error, since statusBarColor was not declared final. Dont know which toolchain you used, but afaik it's not possible to compile on OpenJDK without this. 