### PR TITLE
ios: silence compile error

### DIFF
--- a/ios/RNUnity/RNUnity.h
+++ b/ios/RNUnity/RNUnity.h
@@ -29,7 +29,7 @@
 + (id<RNUnityFramework>)getInstance;
 - (id<RNUnityAppController>)appController;
 
-- (void)setExecuteHeader:(const typeof(_mh_execute_header)*)header;
+- (void)setExecuteHeader:(const void*)header;
 - (void)setDataBundleId:(const char*)bundleId;
 
 - (void)runEmbeddedWithArgc:(int)argc argv:(char*[])argv appLaunchOpts:(NSDictionary*)appLaunchOpts;


### PR DESCRIPTION
This silences a compile error seen when including RNUnity/RNUnity.h from an Objective-C file (main.m) generated based on the latest RN v0.71 app template, complaining about the typeof operator.