### PR TITLE
ensure that Unity is ready for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ export default function App() {
   return (
     <UnityView
       style={{flex: 1, justifyContent: "flex-end"}}
-      onMessage={onMessage}>
+      onMessage={onMessage}
+      onReady={onReady}>
       <View
         style={{
           flexDirection: "row",
@@ -65,6 +66,10 @@ export default function App() {
 
 const onMessage = (data: any) => {
   console.log("Unity message: " + data)
+}
+
+const onReady = () => {
+  console.log("Ready!")
 }
 
 const cubeApi = {

--- a/android/src/main/java/no/fuse/rnunity/RNUnityManager.java
+++ b/android/src/main/java/no/fuse/rnunity/RNUnityManager.java
@@ -84,6 +84,9 @@ public class RNUnityManager extends SimpleViewManager<UnityPlayer> implements Li
         player.requestFocus();
         player.resume();
 
+        // Notify the app that Unity is ready to receive messages
+        RNUnityModule.getInstance().emitEvent("ready", "");
+
         return player;
     }
 

--- a/android/src/main/java/no/fuse/rnunity/RNUnityPackage.java
+++ b/android/src/main/java/no/fuse/rnunity/RNUnityPackage.java
@@ -13,7 +13,7 @@ public class RNUnityPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
         modules.add(new RNUnityModule(reactContext));
-      return modules;
+        return modules;
     }
 
     @Override

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -6,7 +6,8 @@ export default function App() {
   return (
     <UnityView
       style={{flex: 1, justifyContent: "flex-end"}}
-      onMessage={onMessage}>
+      onMessage={onMessage}
+      onReady={onReady}>
       <View
         style={{
           flexDirection: "row",
@@ -38,6 +39,10 @@ export default function App() {
 
 const onMessage = (data: any) => {
   console.log("Unity message: " + data)
+}
+
+const onReady = () => {
+  console.log("Ready!")
 }
 
 const cubeApi = {

--- a/src/UnityView.tsx
+++ b/src/UnityView.tsx
@@ -6,7 +6,11 @@ import { UnityModule } from "./UnityModule"
 const { RNUnity } = NativeModules
 
 export interface UnityViewProps extends ViewProps {
+    /** Called when a message is received from Unity. */
     onMessage?: (message: any) => void
+
+    /** Called when Unity is ready to receive messages. */
+    onReady?: () => void
 }
 
 export class UnityView extends React.Component<UnityViewProps> {
@@ -15,6 +19,10 @@ export class UnityView extends React.Component<UnityViewProps> {
     componentDidMount() {
         if (this.props.onMessage) {
             this.listener = UnityModule.addListener(this.props.onMessage)
+        }
+
+        if (this.props.onReady) {
+            UnityModule.ensureIsReady(this.props.onReady)
         }
     }
 


### PR DESCRIPTION
It is sometimes important to know when Unity is ready to start receiving messages from the React Native app, e.g. to load the right scene as soon as possible.

This commit adds the following functionality to solve the problem:

* ensureIsReady(callback) method in UnityModule
* onReady() callback in UnityView props