### PR TITLE
ios: don't unload Unity

### DIFF
--- a/ios/RNUnity/RNUnity.m
+++ b/ios/RNUnity/RNUnity.m
@@ -115,10 +115,6 @@ RCT_EXPORT_METHOD(initialize) {
     _RNUnity_sharedInstance = self;
 }
 
-RCT_EXPORT_METHOD(unloadUnity) {
-    [self hideUnityWindow];
-}
-
 - (void)startObserving {
     self.hasListeners = YES;
 }
@@ -151,14 +147,6 @@ RCT_EXPORT_METHOD(sendMessage:(NSString *)gameObject
 - (void)emitEvent:(NSString *)name data:(NSString *)data {
     if (self.hasListeners) {
         [self sendEventWithName:name body:data];
-    }
-}
-
-- (void)hideUnityWindow {
-    UIWindow * main = [[[UIApplication sharedApplication] delegate] window];
-    if (main != nil) {
-        [main makeKeyAndVisible];
-        [[RNUnity ufw] unloadApplication];
     }
 }
 

--- a/src/UnityView.tsx
+++ b/src/UnityView.tsx
@@ -51,10 +51,6 @@ class UnityResponderView extends React.Component {
         RNUnity.initialize()
     }
 
-    componentWillUnmount() {
-        RNUnity.unloadUnity()
-    }
-
     render() {
         return (
             <NativeResponderView {...this.props} />


### PR DESCRIPTION
Unloading Unity makes everything seem "stuck" when creating a second UnityView on iOS, so don't do this.