### PR TITLE
ios: pause/resume when unmounting/mounting UnityView

### DIFF
--- a/ios/RNUnity/RNUnity.m
+++ b/ios/RNUnity/RNUnity.m
@@ -136,6 +136,18 @@ RCT_EXPORT_METHOD(initialize) {
     return dispatch_get_main_queue();
 }
 
+RCT_EXPORT_METHOD(pause) {
+    if (_RNUnity_sharedInstance) {
+        [[RNUnity ufw] pause:true];
+    }
+}
+
+RCT_EXPORT_METHOD(resume) {
+    if (_RNUnity_sharedInstance) {
+        [[RNUnity ufw] pause:false];
+    }
+}
+
 RCT_EXPORT_METHOD(sendMessage:(NSString *)gameObject
                   functionName:(NSString *)functionName
                   message:(NSString *)message) {

--- a/src/UnityView.tsx
+++ b/src/UnityView.tsx
@@ -57,6 +57,11 @@ const NativeUnityView = requireNativeComponent<ViewProps>("UnityView")
 class UnityResponderView extends React.Component {
     componentDidMount() {
         RNUnity.initialize()
+        RNUnity.resume()
+    }
+
+    componentWillUnmount() {
+        RNUnity.pause()
     }
 
     render() {


### PR DESCRIPTION
We don't want audio to keep playing in the background after leaving a page containing UnityView.