### PR TITLE
feature: Keep Awake

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ export default function App() {
     <UnityView
       style={{flex: 1, justifyContent: "flex-end"}}
       onMessage={onMessage}
-      onReady={onReady}>
+      onReady={onReady}
+      keepAwake={true}>
       <View
         style={{
           flexDirection: "row",

--- a/android/src/main/java/no/fuse/rnunity/RNUnityModule.java
+++ b/android/src/main/java/no/fuse/rnunity/RNUnityModule.java
@@ -1,6 +1,10 @@
 
 package no.fuse.rnunity;
 
+import android.app.Activity;
+import android.util.Log;
+import android.view.WindowManager;
+
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -17,9 +21,12 @@ public class RNUnityModule extends ReactContextBaseJavaModule {
         return instance;
     }
 
+    boolean keepAwake;
+
     public RNUnityModule(ReactApplicationContext reactContext) {
         super(reactContext);
         instance = this;
+        keepAwake = false;
     }
 
     @Override
@@ -46,5 +53,30 @@ public class RNUnityModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void removeListeners(Integer count) {
         // Dummy method
+    }
+
+    public boolean getKeepAwake() {
+        return keepAwake;
+    }
+
+    @ReactMethod
+    public void setKeepAwake(boolean enabled) {
+        keepAwake = enabled;
+        final Activity activity = getCurrentActivity();
+
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (keepAwake) {
+                        Log.d("RNUnityModule", "Turning on keep awake");
+                        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    } else {
+                        Log.d("RNUnityModule", "Turning off keep awake");
+                        activity.getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                    }
+                }
+            });
+        }
     }
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,8 @@ export default function App() {
     <UnityView
       style={{flex: 1, justifyContent: "flex-end"}}
       onMessage={onMessage}
-      onReady={onReady}>
+      onReady={onReady}
+      keepAwake={true}>
       <View
         style={{
           flexDirection: "row",

--- a/ios/RNUnity/RNUnity.m
+++ b/ios/RNUnity/RNUnity.m
@@ -167,4 +167,10 @@ RCT_EXPORT_METHOD(sendMessage:(NSString *)gameObject
     }
 }
 
+RCT_EXPORT_METHOD(setKeepAwake:(BOOL)keepAwake) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] setIdleTimerDisabled:keepAwake];
+    });
+}
+
 @end

--- a/src/UnityModule.ts
+++ b/src/UnityModule.ts
@@ -30,6 +30,11 @@ export interface UnityModule {
      * @param message The argument to pass.
      */
     sendMessage(gameObject: string, methodName: string, message: string): void
+
+    /**
+     * Sets whether the screen should stay on.
+     */
+    setKeepAwake(enabled: boolean): void
 }
 
 class UnityModuleImpl implements UnityModule {
@@ -93,6 +98,10 @@ class UnityModuleImpl implements UnityModule {
 
     sendMessage(gameObject: string, methodName: string, message: string) {
         RNUnity.sendMessage(gameObject, methodName, message)
+    }
+
+    setKeepAwake(enabled: boolean) {
+        RNUnity.setKeepAwake(enabled)
     }
 }
 

--- a/src/UnityView.tsx
+++ b/src/UnityView.tsx
@@ -11,6 +11,9 @@ export interface UnityViewProps extends ViewProps {
 
     /** Called when Unity is ready to receive messages. */
     onReady?: () => void
+
+    /** Sets whether the screen should stay on. */
+    keepAwake?: boolean
 }
 
 export class UnityView extends React.Component<UnityViewProps> {
@@ -24,9 +27,17 @@ export class UnityView extends React.Component<UnityViewProps> {
         if (this.props.onReady) {
             UnityModule.ensureIsReady(this.props.onReady)
         }
+
+        if (this.props.keepAwake) {
+            UnityModule.setKeepAwake(this.props.keepAwake)
+        }
     }
 
     componentWillUnmount() {
+        if (this.props.keepAwake) {
+            UnityModule.setKeepAwake(false)
+        }
+
         this.listener?.remove()
     }
 


### PR DESCRIPTION
There are other React Native modules to use this feature[1], but unfortunately we get race condition on Android because two pieces of asynchronous code are manipulating window flags at the same time, and it might work or not depending on the device you're using.

This fixes the problem by implementing Keep Awake directly in this module so that we can add some extra glue on Android and make sure things will work as intended.

* Use the keepAwake prop on UnityView to turn this on and off

1: e.g. @sayem314/react-native-keep-awake