### PR TITLE
example: Install rimraf -> 4.4.1

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -31,6 +31,7 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "18.3.1",
+    "rimraf": "^4.4.1",
     "typescript": "5.0.4"
   },
   "engines": {


### PR DESCRIPTION
Fixes an error when running unpack.mjs.